### PR TITLE
Los Drawer guardan los cambios

### DIFF
--- a/Editor/ExternalReference/ExternalReferenceDrawer.cs
+++ b/Editor/ExternalReference/ExternalReferenceDrawer.cs
@@ -23,7 +23,7 @@ namespace HyperGnosys.Core
             SerializedProperty referencedObjectPoperty = property.FindPropertyRelative("referenceObject");
             referencedObjectPoperty.objectReferenceValue = 
                 EditorGUI.ObjectField(controlRect, referencedObjectPoperty.objectReferenceValue, typeof(Object), true);
-
+            property.serializedObject.ApplyModifiedProperties();
             EditorGUI.EndProperty();
         }
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)

--- a/Editor/Property/ObservableProperty/ExternalizableObservablePropertyDrawer.cs
+++ b/Editor/Property/ObservableProperty/ExternalizableObservablePropertyDrawer.cs
@@ -46,6 +46,7 @@ namespace HyperGnosys.Core
                 GUIContent externalPropertyLabel = new GUIContent("External Property");
                 EditorGUI.PropertyField(propertyRect, selectedProperty, externalPropertyLabel, true);
             }
+            property.serializedObject.ApplyModifiedProperties();
             EditorGUI.EndProperty();
         }
         private bool DropDownButton(Rect rect)

--- a/Editor/Property/TaggedProperty/ExternalReference/TaggedPropertyExternalReferenceDrawer.cs
+++ b/Editor/Property/TaggedProperty/ExternalReference/TaggedPropertyExternalReferenceDrawer.cs
@@ -41,6 +41,7 @@ namespace HyperGnosys.Core
             GUI.enabled = true;
             lines.Add(referencedPropertyRect);
 
+            property.serializedObject.ApplyModifiedProperties();
             EditorGUI.EndProperty();
         }
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)

--- a/Editor/Property/TaggedProperty/ExternalizableTaggedPropertyDrawer.cs
+++ b/Editor/Property/TaggedProperty/ExternalizableTaggedPropertyDrawer.cs
@@ -49,6 +49,7 @@ namespace HyperGnosys.Core
                 GUIContent externalPropertyLabel = new GUIContent("External Property");
                 EditorGUI.PropertyField(propertyRect, selectedProperty, externalPropertyLabel, true);
             }
+            property.serializedObject.ApplyModifiedProperties();
             EditorGUI.EndProperty();
         }
         private bool DropDownButton(Rect rect)


### PR DESCRIPTION
Falto agregar la linea que hace que los cambios realizados en los Drawers se preserven. Sin eso tan pronto dejas de ver la pantalla se borran los cambios, por lo que al dar Play nada está configurado.