### PR TITLE
Quickfix en PropertyGroups

### DIFF
--- a/Runtime/ExternalizableProperty/ObservableProperty/LabeledProperty/TaggedProperty/Group/TaggedPropertyGroup.cs
+++ b/Runtime/ExternalizableProperty/ObservableProperty/LabeledProperty/TaggedProperty/Group/TaggedPropertyGroup.cs
@@ -9,7 +9,7 @@ namespace HyperGnosys.Core
         ISerializationCallbackReceiver, 
         ITaggedPropertyGroup<PropertyType>
     {
-        [SerializeField] private TaggedProperty<PropertyType>[] properties;
+        [SerializeField] private TaggedProperty<PropertyType>[] properties = new TaggedProperty<PropertyType>[0];
 
         //After serialization is done, load the array that survived serialization
         //into the dictionary so it can be used.

--- a/Samples/Scenes/TaggedPropertySample.unity
+++ b/Samples/Scenes/TaggedPropertySample.unity
@@ -1259,56 +1259,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 438699580}
   m_CullTransparentMesh: 1
---- !u!1 &476179040
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 476179042}
-  - component: {fileID: 476179041}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &476179041
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476179040}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54e01d9228b9cdd41a6a9c09f4298513, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  eventListener:
-    debugging: 0
-    gameEvent:
-      referenceObject: {fileID: 0}
-    responses:
-      m_PersistentCalls:
-        m_Calls: []
---- !u!4 &476179042
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476179040}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 222.55377, y: 85.985, z: -61.564995}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &502391695
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Ya no lanzan error al agregarse como componente. Al agregarse no estaba inicializado el array y eso provocaba errores la serialización